### PR TITLE
fix: prevent repeated document extraction on page reload after upload

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,50 +100,62 @@ def create_vector_store(extracted_file_paths):
 # Sidebar configuration for file uploads
 if 'uploaded_files' not in st.session_state:
     st.session_state.uploaded_files = None
+    st.session_state.uploaded_files_bool = False
+    st.session_state['prev_uploaded_files'] = []
 
 with st.sidebar:
     st.subheader("Upload your document")
-    st.session_state.uploaded_files = st.sidebar.file_uploader(
+    uploaded_files = st.sidebar.file_uploader(
         "Choose files", accept_multiple_files=True, type=["pdf", "txt", "pptx"], key="initial"
     )
     
-    if st.session_state.uploaded_files:
-        if len(st.session_state.uploaded_files) > 2:
-            st.error("You can only upload a maximum of 2 documents.")
-            logging.warning("User attempted to upload more than 2 documents.")
-            st.session_state.uploaded_files = None
-        else:
-            valid_files = []
-            valid_file = True
-            for file in st.session_state.uploaded_files:
-                if allowed_files(file.name):
-                    num_pages = file_check_num(file)
-                    if num_pages > 50:
-                        st.error(f"{file.name} exceeds the 50-page limit (has {num_pages} pages).")
-                        logging.warning(f"File {file.name} exceeds the page limit.")
+    # Check for changes in the uploaded files
+    if uploaded_files:
+        uploaded_file_names = [file.name for file in uploaded_files]
+        prev_file_names = [file.name for file in st.session_state['prev_uploaded_files']]
+        
+        # Check if there's any difference between the current and previous file names
+        if uploaded_file_names != prev_file_names:
+            st.session_state.uploaded_files = uploaded_files
+            st.session_state['prev_uploaded_files'] = uploaded_files
+
+            if len(uploaded_files) > 2:
+                st.error("You can only upload a maximum of 2 documents.")
+                logging.warning("User attempted to upload more than 2 documents.")
+                st.session_state.uploaded_files = None
+            else:
+                valid_files = []
+                valid_file = True
+                for file in uploaded_files:
+                    if allowed_files(file.name):
+                        num_pages = file_check_num(file)
+                        if num_pages > 50:
+                            st.error(f"{file.name} exceeds the 50-page limit (has {num_pages} pages).")
+                            logging.warning(f"File {file.name} exceeds the page limit.")
+                            valid_file = False
+                            break
+                        else:
+                            valid_files.append(file)
+                    else:
+                        st.error(f"{file.name} is not a valid file type.")
+                        logging.warning(f"Invalid file type: {file.name}")
                         valid_file = False
                         break
-                    else:
-                        valid_files.append(file)
-                else:
-                    st.error(f"{file.name} is not a valid file type.")
-                    logging.warning(f"Invalid file type: {file.name}")
-                    valid_file = False
-                    break
 
-            if valid_file and valid_files:
-                try:
-                    extraction_results = extract_contents_from_doc(valid_files, "temp_dir")
-                    vector_store = create_vector_store(extraction_results)
-                    if vector_store:
-                        st.session_state['vector_store'] = vector_store
-                        st.success(f"{len(st.session_state.uploaded_files)} file(s) uploaded and processed successfully.")
-                        logging.info("File(s) uploaded and processed successfully.")
-                except Exception as e:
-                    st.error("An error occurred while processing your document. Please try again.")
-                    logging.error(f"Error extracting content from document: {e}")
+                if valid_file and valid_files:
+                    try:
+                        extraction_results = extract_contents_from_doc(valid_files, "temp_dir")
+                        vector_store = create_vector_store(extraction_results)
+                        if vector_store:
+                            st.session_state['vector_store'] = vector_store
+                            st.success(f"{len(uploaded_files)} file(s) uploaded and processed successfully.")
+                            logging.info("File(s) uploaded and processed successfully.")
+                    except Exception as e:
+                        st.error("An error occurred while processing your document. Please try again.")
+                        logging.error(f"Error extracting content from document: {e}")
     else:
         st.session_state.uploaded_files = None
+        st.session_state['prev_uploaded_files'] = []
         
     st.subheader("Speech output responses")
     if 'speech_outputs' in st.session_state:

--- a/main.py
+++ b/main.py
@@ -100,7 +100,6 @@ def create_vector_store(extracted_file_paths):
 # Sidebar configuration for file uploads
 if 'uploaded_files' not in st.session_state:
     st.session_state.uploaded_files = None
-    st.session_state.uploaded_files_bool = False
     st.session_state['prev_uploaded_files'] = []
 
 with st.sidebar:


### PR DESCRIPTION
- Added a `prev_uploaded_files` flag in session state to ensure documents are extracted only once per upload.
- Previously, each interaction (e.g., sending a query) triggered Streamlit to re-run the entire script, causing document extraction to repeat even if files were unchanged.
- Now, document extraction occurs only when new files are uploaded or existing files are removed, significantly reducing redundant processing.